### PR TITLE
should only accept first h1 title, if there are several h1 titles or code comments

### DIFF
--- a/src/markdown/Serializer.ts
+++ b/src/markdown/Serializer.ts
@@ -76,7 +76,7 @@ export class Serializer {
   }
 
   deckName(rawCards: string[]): string | null {
-    const deckName = rawCards.reduce((acc, str) => {
+    const deckName = rawCards.reduceRight((acc, str) => {
       const match = str.match(
         new RegExp(this.getConfig("deck.titleSeparator") as string, "m")
       );

--- a/src/markdown/__tests__/Serializer.test.ts
+++ b/src/markdown/__tests__/Serializer.test.ts
@@ -71,5 +71,19 @@ describe("Serializer", () => {
       // Assert
       expect(result).toEqual(deckName);
     });
+    it("should only accept first h1 title", () => {
+      // Arrange
+      const deckName = "Test Title";
+      const input = [
+        `# ${deckName}\r\rextra stuff before the card`,
+        "## Some Card\rCard text",
+        `# other title`
+      ];
+      const serializer = new Serializer(new MarkdownFile(null), false);
+      // Act
+      const result = serializer.deckName(input);
+      // Assert
+      expect(result).toEqual(deckName);
+    });
   });
 });


### PR DESCRIPTION
In most cases, I have ruby codes in my cards.
Its comment is like this `# this is a comment`, this will override the expected deckName.


sample markdown content:
----

> \# title
> 
> \```rb
> \# it print 3
> puts 3
> \```

The title should be "title", not "it print 3"