### PR TITLE
Replace Markdown ##, such that not translated into H2 HTML tags

### DIFF
--- a/src/markdown/parsers/cardParser.ts
+++ b/src/markdown/parsers/cardParser.ts
@@ -135,7 +135,7 @@ export class CardParser extends BaseParser {
    * @private
    */
   async linesToHtml(lines: string[]) {
-    const string = lines.join("\n");
+    const string = lines.join("\n").replace("## ", "");
 
     const mdString = await new MdParser({}).parse(string);
     if (!this.options.convertMath) {


### PR DESCRIPTION
Hi @jasonwilliams. As suggested, a tiny change to prevent the inclusion of the second level markdown headings (##) into the HTML of Anki cards.