### PR TITLE
Adding embeddable cards in a backward compatible way.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to the "anki" extension will be documented in this file.
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## [1.2.8]
+- Embeddable Cards definitions. Extract `text` for processing from `<!-- BEGIN_ANKI_CARDS -->text<!-- END_ANKI_CARDS -->` match in the Markdown file.
+
 ## [1.2.7]
 
 - Fix bug that LaTeX curly brackets do not convert correctly [#63](https://github.com/jasonwilliams/anki/issues/63)

--- a/README.md
+++ b/README.md
@@ -85,6 +85,27 @@ necessary.
 
 When parsing only one markdown file, the title of the deck could be generated based on the top-level headline (`#`).
 
+To embed cards definitions in the existing document, one can limit the scope of the document to be processed between one or more matching pairs of
+`<!-- BEGIN_ANKI_CARDS -->` and `<!-- END_ANKI_CARDS -->` markdown comments.
+```
+# Anki for VSCode
+
+This is a VSCode extension for interacting and sending cards to Anki.  
+It uses AnkiConnect for communication so you will need this extension installed and running before installing the VSCode extension.
+
+<!-- BEGIN_ANKI_CARDS -->
+
+## What is the name of the most awesome VSCode plugin?
+
+It is `Anki for VSCode` of course.
+
+## What "Anki for VSCode" requires to function?
+
+It requires AnkiConnect
+
+<!-- END_ANKI_CARDS -->
+```
+
 ### Cloze
 
 You can make Cloze deletions in the card title `## A bit like {{c1::this}}`.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "anki",
   "displayName": "Anki for VSCode",
   "description": "Sync notes with your locally running Anki",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "publisher": "jasew",
   "engines": {
     "vscode": "^1.66.0"


### PR DESCRIPTION
Added embeddable cards in a backward-compatible way. Allows limiting the scope of the processing to the content between `<!-- BEGIN_ANKI_CARDS -->` and `<!-- END_ANKI_CARDS -->` comments.

I found it helpful to embed the Anki Cards definitions into documents with some knowledge base data.
This change is backward compatible and should work with all the existing features from how far I've tested.