### PR TITLE
Parse nodeIDs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14810,8 +14810,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "acorn-walk": {
       "version": "7.2.0",
@@ -21385,6 +21384,16 @@
           "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
           "dev": true
         }
+      }
+    },
+    "string-length": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
+      "integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
+      "dev": true,
+      "requires": {
+        "char-regex": "^1.0.2",
+        "strip-ansi": "^6.0.0"
       }
     },
     "string_decoder": {

--- a/package.json
+++ b/package.json
@@ -136,6 +136,11 @@
           "type": "boolean",
           "default": true,
           "description": "When you run 'Send To Deck' the title (h1) of the markdown file is stored as a tag. This is useful if you have 'daily' notes, you can use the same deck but separate cards by title"
+        },
+        "anki.md.card.notecardIdPattern": {
+          "type": "string",
+          "default": "<!--\\s*?notecardId\\s*?\\[:=\\]\\s*?(\\d+)\\s*?-->",
+          "description": "Text to match match the commented notecard ID."
         }
       }
     }

--- a/src/markdown/parsers/__tests__/cardParser.test.ts
+++ b/src/markdown/parsers/__tests__/cardParser.test.ts
@@ -9,7 +9,7 @@ describe("CardParser", () => {
   afterAll(() => {
     jest.resetAllMocks();
   });
-  describe("Good Input", () => {
+ describe("Good Input", () => {
     it("constructs without erroring", () => {
       assert.doesNotThrow(() => {
         new CardParser();
@@ -71,6 +71,17 @@ describe("CardParser", () => {
 
       expect(card.tags).toContain("myTag");
     });
+
+    // Should parse the note ID properly
+    it("should parse the note ID properly", async () => {
+        const input =
+          "## Some text that should be on the front\n\n<!-- notecardId: 123 -->\nThis text will be on the back\n\n[#myTag]()";
+        const parser = new CardParser();
+        const card = await parser.parse(input);
+
+        expect(card.noteId).toBe(123);
+        expect(card.answer).toBe("<p>This text will be on the back</p>\n");
+      });
   });
 
   describe("Bad Input", () => {

--- a/src/models/Card.ts
+++ b/src/models/Card.ts
@@ -16,12 +16,14 @@ export class Card {
     question: string,
     answer: string,
     tags: string[] = [],
+        noteId: number = 0,
     model: string = CONSTANTS.defaultTemplateName
   ) {
     this.question = question;
     this.answer = answer;
     this.tags = tags;
     this.modelName = model;
+    this.noteId = noteId
 
     // The fields need to match the template, cloze has different fields
     if (this.modelName === CONSTANTS.defaultTemplateName) {


### PR DESCRIPTION
This change allows for a parsing of note IDs. This is the first step in allowing (eventually) the automatic storing of the created note ID in the markdown file.