### PR TITLE
Update markdown when creating new cards

### DIFF
--- a/package.json
+++ b/package.json
@@ -150,6 +150,11 @@
           "type": "boolean",
           "default": false,
           "description": "Opt in to allow parsed noteIDs to be used for updating existing anki cards. Note: Update doesn't care which deck the card with each noteID are, see: https://github.com/jasonwilliams/anki/pull/106#issuecomment-1483743818"
+        },
+        "anki.md.insertNewCardID": {
+          "type": "boolean",
+          "default": false,
+          "description": "Opt in to allow inserting newly created note IDs."
         }
       }
     }

--- a/src/AnkiService.ts
+++ b/src/AnkiService.ts
@@ -21,8 +21,10 @@ export class AnkiService {
   }
 
   async invoke(action: string, params?: object): Promise<any> {
+    console.log("{ ...params }: %s", { ...params });
     const req = { action, version: this.version, params: { ...params } };
     getLogger().trace(JSON.stringify(req));
+    console.log("JSON.stringify(req): %s", JSON.stringify(req));
     const response = await fetch(this.url, {
       method: "post",
       headers: {

--- a/src/AnkiService.ts
+++ b/src/AnkiService.ts
@@ -21,10 +21,8 @@ export class AnkiService {
   }
 
   async invoke(action: string, params?: object): Promise<any> {
-    console.log("{ ...params }: %s", { ...params });
     const req = { action, version: this.version, params: { ...params } };
     getLogger().trace(JSON.stringify(req));
-    console.log("JSON.stringify(req): %s", JSON.stringify(req));
     const response = await fetch(this.url, {
       method: "post",
       headers: {

--- a/src/markdown/transformer.ts
+++ b/src/markdown/transformer.ts
@@ -83,7 +83,6 @@ export class Transformer {
         headerLineNumbers.push(index);
       }
     });
-    console.log("headerLineNumbers: %s", headerLineNumbers);
 
     // Now need to correlate the header lines with which card they match
     // I have to have a line number such that I can create a position
@@ -109,7 +108,6 @@ export class Transformer {
         }
       });
     });
-    console.log("[...lineIndexToNoteID.entries()]: %s", [...lineIndexToNoteID.entries()]);
 
     // https://github.com/microsoft/vscode-extension-samples/blob/main/document-editing-sample/src/extension.ts
     const editor = window.activeTextEditor;

--- a/src/markdown/transformer.ts
+++ b/src/markdown/transformer.ts
@@ -98,7 +98,8 @@ export class Transformer {
     }
   }
 
-  async exportCards(cards: Card[]) {
+  // Going to return a list of cards that require their note IDs to be added to the file's markdown
+  async exportCards(cards: Card[]): Card[] {
     this.addCardsToDeck(cards);
     if (!this.deck) {
       throw new Error("No Deck exists for current cards");

--- a/src/markdown/transformer.ts
+++ b/src/markdown/transformer.ts
@@ -63,7 +63,9 @@ export class Transformer {
     // this.exportCards will return a list of Cards that were just created. Thus we need to insert their note IDs into the markdown
     const newCards = await this.exportCards(cards);
     // Call to insert noteID into markdown
-    this.insertNoteIDs(newCards);
+    if (this.getConfig("insertNewCardID")) {
+      this.insertNoteIDs(newCards);
+    }
 
     return new SendDiff(); // dummy return for the first pull request
   }

--- a/src/models/Deck.ts
+++ b/src/models/Deck.ts
@@ -116,7 +116,7 @@ export class Deck {
     return Promise.all(cards.map((card) => this.ankiService?.updateFields(card)));
   }
 
-  async createAndUpdateCards() {
+  async createAndUpdateCards(): Promise<Card[]> {
     // Push the updated cards (based on noteID)
     let updateCards: Card[] = [];
     let newCards: Card[] = [];
@@ -125,6 +125,7 @@ export class Deck {
       await this._pushUpdatedCardsToAnki(updateCards);
     }
     await this._pushNewCardsToAnki(newCards);
+    return newCards
   }
 
   // Anki Service Methods


### PR DESCRIPTION
I'm looking for a strong/less brittle way of matching the front of the card to what actually exists in the markdown. Right now bold `**` or other markdown formatting breaks the line matching I have. What I really want is any easy way to reverse engineer a given HTML string into markdown and use that for the line matching. Do you know of any good packages for this?