### PR TITLE
Check both front and back for metadata to avoid generating new CardIDs

### DIFF
--- a/src/markdown/parsers/cardParser.ts
+++ b/src/markdown/parsers/cardParser.ts
@@ -69,7 +69,7 @@ export class CardParser extends BaseParser {
     let noteId = 0;
     let isCloze = false;
 
-    const fillBackAndTags = (line: string) => {
+    const appendLine = (line: string, dest: string[]) => {
       // set tags
       if (this.tagRe.test(line)) {
         tags.push(...this.parseTags(line));
@@ -85,13 +85,13 @@ export class CardParser extends BaseParser {
         }
       }
 
-      // set back
+      // set dest
       // skip first blank lines
-      if (back.length === 0 && !line) {
+      if (dest.length === 0 && !line) {
         return;
       }
 
-      back.push(line);
+      dest.push(line);
     };
 
     if (cardLines.length === 1) {
@@ -106,13 +106,12 @@ export class CardParser extends BaseParser {
           return;
         }
 
-        fillBackAndTags(line);
+        appendLine(line, back);
       });
     } else {
       // front card has multiple lines
-      front.push(...cardLines[0]);
-
-      trimArray(cardLines[1]).forEach((line: string) => fillBackAndTags(line));
+      trimArray(cardLines[0]).forEach((line: string) => appendLine(line, front));
+      trimArray(cardLines[1]).forEach((line: string) => appendLine(line, back));
     }
 
     return {


### PR DESCRIPTION
To reproduce bug #128, enable anki.md.insertNewCardID and run Anki:Send To Own Deck multiple times on this deck and note that it generates new CardIDs each time:

```
# Test CardID Bug

## Front (2024-06-08 19:51:42)
%
Back (2024-06-08 19:51:42)

## Front (2024-06-08 19:51:56)

%
Back (2024-06-08 19:51:56)

## Front (2024-06-08 19:52:04)
%

Back (2024-06-08 19:52:04)

## Front (2024-06-08 19:52:13)

%

Back (2024-06-08 19:52:13)

## Front (2024-06-08 19:52:20)
Back (2024-06-08 19:52:20)

## Front (2024-06-08 19:52:25)

Back (2024-06-08 19:52:25)
```

Apply the fix and repeat the test to see that the CardIDs are only generated once..