### PR TITLE
Fix issue #121 by sending each card separately to avoid overloading a…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "anki",
-  "version": "1.3.2",
+  "version": "1.3.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "anki",
-      "version": "1.3.2",
+      "version": "1.3.4",
       "license": "MIT",
       "dependencies": {
         "cheerio": "^1.0.0-rc.10",

--- a/src/models/Deck.ts
+++ b/src/models/Deck.ts
@@ -122,9 +122,13 @@ export class Deck {
     let newCards: Card[] = [];
     this.cards.forEach((card) => (card.noteId ? updateCards.push(card) : newCards.push(card)));
     if (workspace.getConfiguration("anki.md").get("updateCards")) {
-      await this._pushUpdatedCardsToAnki(updateCards);
+      for (const card of updateCards.values()) {
+        await this._pushUpdatedCardsToAnki([card]);
+      }
     }
-    await this._pushNewCardsToAnki(newCards);
+    for (const card of newCards.values()) {
+      await this._pushNewCardsToAnki([card]);
+    }
     return newCards;
   }
 


### PR DESCRIPTION
…nki-connect.

Before applying the fix, create a large deck as described in #121 and send it to Anki. Resending the deck a second time without any changes may trigger a disconnection error. Changing the cards using sed as described in #121 and resending will most likely trigger a disconnection error.

Apply the fix and repeat to see that the error no longer happens.

Please note that I bumped the version to 1.3.4 because 1.3.3 was already released.  The marketplace version acted like it was out of date even though the version said 1.3.3.