### PR TITLE
Update README.md - updateCards requires insertNewCardID

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Here's an example
 
 ### Update cards (Beta)
 
-You can update a card that you've already sent to a deck. To do this make sure you enable by setting `anki.md.updateCards` to `true`.
+You can update a card that you've already sent to a deck. To do this make sure you enable by setting `anki.md.updateCards` to `true` as well as `anki.md.insertNewCardID` to `true`.
 This feature is currently opt-in but we may turn it on by default in the future.
 
 This feature relies on the NoteID being embedded in the card and searches the Anki Database for that same noteID then updates, this means, if you're using `Send to dirname deck` it [may not](https://github.com/jasonwilliams/anki/pull/106#issuecomment-1483743818) go to the place you were expecting.


### PR DESCRIPTION
Hi, thanks for the introduction of note updates. It was my pain point number 1 with the extension for a long time. So thank you and the contributors!

## Changes

- docs: when enabling `anki.md.updateCards`, add remark that `anki.md.insertNewCardID` should be enabled, too.

## Background

When migrating to updating notes however, I ran into `Error: ['cannot create note because it is a duplicate']`.

Using the docs to set `updateCards` to `true` did not solve the issue. Only checking the gh issues and reading about the `insertNewCardID` flag in https://github.com/jasonwilliams/anki/issues/122 I noticed what's wrong.

So apparently `anki.md.updateCards` requires `anki.md.insertNewCardID`.

If this is a wrong interpretation of what went wrong, feel free to close this PR.

## Note

This _might_ be a migration issue. I installed the extension a long time ago. I am unaware of whether `anki.md.insertNewCardID` is set to true by defaults for new installs or not.

